### PR TITLE
Fix undefined behaviour

### DIFF
--- a/SP5WWP/m17-decoder/golay.c
+++ b/SP5WWP/m17-decoder/golay.c
@@ -40,7 +40,7 @@ uint16_t SoftToInt(const uint16_t* in, uint8_t len)
 //result=a/b
 uint16_t Div16(uint16_t a, uint16_t b)
 {
-	uint32_t aa=a<<16;
+	uint32_t aa=(uint32_t)a<<16;
 	uint32_t r=aa/b;
 
 	if(r<=0xFFFF)

--- a/SP5WWP/m17-decoder/viterbi.c
+++ b/SP5WWP/m17-decoder/viterbi.c
@@ -162,7 +162,7 @@ uint32_t chainback(uint8_t* out, size_t pos, uint16_t len)
 
     memset(out, 0, (len-1)/8+1);
 
-    while(bitPos > 0)
+    while(pos > 0)
     {
         bitPos--;
         pos--;


### PR DESCRIPTION
Compiling m17-coder and m17-decoder with `-fsanitize=undefined -fsanitize=address` and running `test-enc-dec.sh` reveals the following instances of Undefined Behaviour:

```
golay.c:43:15: runtime error: left shift of 65535 by 16 places cannot be represented in type 'int'
viterbi.c:169:31: runtime error: index 18446744073709551615 out of bounds for type 'uint16_t [244]'
```

The first occurs because `a << 16` promotes `a` to `int`, which is not large enough to hold the result. Explicitly casting it to `uint32_t` solves the problem.

The second occurs because the `chainback` function writes to a bit-packed output buffer and rounds up `bitPos` to a multiple of 8, presumably to right-align the output bits. But the `history` array does not have entries for these extra bits, and so `pos` ends up going down to -4 and reading beyond the beginning of the array. Ending the loop when `pos` reaches zero solves the problem. The padding bits in the output will be zero because they are initialized on line 163, so I don't think there's any need to explicitly set them in the loop.