### PR TITLE
Fix reads from stdin

### DIFF
--- a/SP5WWP/m17-coder/m17-coder-sym.c
+++ b/SP5WWP/m17-coder/m17-coder-sym.c
@@ -241,11 +241,11 @@ int main(void)
         if(got_lsf) //stream frames
         {
             //we could discard the data we already have
-            while(read(STDIN_FILENO, &(lsf.dst), 6)<6);
-            while(read(STDIN_FILENO, &(lsf.src), 6)<6);
-            while(read(STDIN_FILENO, &(lsf.type), 2)<2);
-            while(read(STDIN_FILENO, &(lsf.meta), 14)<14);
-            while(read(STDIN_FILENO, data, 16)<16);
+            while(fread(&(lsf.dst), 1, 6, stdin)<1);
+            while(fread(&(lsf.src), 1, 6, stdin)<1);
+            while(fread(&(lsf.type), 1, 2, stdin)<1);
+            while(fread(&(lsf.meta), 1, 14, stdin)<1);
+            while(fread(data, 1, 16, stdin)<1);
 
             //send stream frame syncword
             send_Syncword(SYNC_STR);
@@ -383,11 +383,11 @@ int main(void)
         }
         else //LSF
         {
-            while(read(STDIN_FILENO, &(lsf.dst), 6)<6);
-            while(read(STDIN_FILENO, &(lsf.src), 6)<6);
-            while(read(STDIN_FILENO, &(lsf.type), 2)<2);
-            while(read(STDIN_FILENO, &(lsf.meta), 14)<14);
-            while(read(STDIN_FILENO, data, 16)<16);
+            while(fread(&(lsf.dst), 1, 6, stdin)<1);
+            while(fread(&(lsf.src), 1, 6, stdin)<1);
+            while(fread(&(lsf.type), 1, 2, stdin)<1);
+            while(fread(&(lsf.meta), 1, 14, stdin)<1);
+            while(fread(data, 1, 16, stdin)<1);
 
             //calculate LSF CRC
             uint16_t ccrc=LSF_CRC(&lsf);

--- a/SP5WWP/m17-decoder/m17-decoder-sym.c
+++ b/SP5WWP/m17-decoder/m17-decoder-sym.c
@@ -94,7 +94,7 @@ int main(void)
     while(1)
     {
         //wait for another symbol
-        while(read(STDIN_FILENO, (uint8_t*)&sample, 4)<4);
+        while(fread((uint8_t*)&sample, 1, 4, stdin)<1);
 
         if(!syncd)
         {

--- a/SP5WWP/m17-decoder/m17-decoder.c
+++ b/SP5WWP/m17-decoder/m17-decoder.c
@@ -21,7 +21,7 @@ int main(void)
     while(1)
     {
         //wait for another baseband sample
-        while(read(STDIN_FILENO, (uint8_t*)&sample, 2)<2);
+        while(fread((uint8_t*)&sample, 1, 2, stdin)<1);
 
         //push the root-nyquist filter's buffer
         for(uint8_t i=0; i<FLT_LEN-1; i++)


### PR DESCRIPTION
The `test-enc-dec.sh` script fails after some time with CRC errors. This happens because m17-coder and m17-decoder use `read` to get data from stdin, and this call may return fewer bytes than requested. In that case, the existing `while` loops simply discard the partial data, thereby resulting in data loss.

To fix the problem, I've switched to `fread`. By requesting for one item of size `n`, the call is guaranteed to return either `n` bytes or 0, avoiding the situation where partial data is returned.