### PR TITLE
Ignore generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/SP5WWP/grc/m17_streamer.py
+/SP5WWP/grc/symbol_recovery.py
+/SP5WWP/m17-coder/m17-coder-sym
+/SP5WWP/m17-decoder/m17-decoder-sym


### PR DESCRIPTION
Here I've added a `.gitignore` file so that git will ignore Python code generated by GRC and binaries produced by the compiler.