### PR TITLE
Add null termination after callsign

### DIFF
--- a/SP5WWP/m17-decoder/m17-decoder-sym.c
+++ b/SP5WWP/m17-decoder/m17-decoder-sym.c
@@ -87,6 +87,7 @@ void decode_callsign(uint8_t *outp, const uint8_t *inp)
 		encoded/=40;
 		i++;
 	}
+	outp[i]=0;
 }
 
 int main(void)


### PR DESCRIPTION
The `decode_callsign` function fails to null-terminate the decoded callsign, which can result in uninitialized memory being printed out, e.g.:

`DST: #BCAST    SRC: AB1CDE�� TYPE: 0005 META: 0000000000000000000000000000 LSF_CRC_OK`

Adding a null termination fixes this.