### PR TITLE
Correctly handle EoF, and transmit EoT

### DIFF
--- a/SP5WWP/m17-coder/m17-coder-sym.c
+++ b/SP5WWP/m17-coder/m17-coder-sym.c
@@ -16,17 +16,18 @@ struct LSF
 	uint8_t type[2];
 	uint8_t meta[112/8];
 	uint8_t crc[2];
-} lsf;
+} lsf, next_lsf;
 
 uint8_t lich[6];                    //48 bits packed raw, unencoded LICH
 uint8_t lich_encoded[12];           //96 bits packed, encoded LICH
 uint8_t enc_bits[SYM_PER_PLD*2];    //type-2 bits, unpacked
 uint8_t rf_bits[SYM_PER_PLD*2];     //type-4 bits, unpacked
 
-uint8_t data[16];                   //raw payload, packed bits
+uint8_t data[16], next_data[16];    //raw payload, packed bits
 uint16_t fn=0;                      //16-bit Frame Number (for the stream mode)
 uint8_t lich_cnt=0;                 //0..5 LICH counter, derived from the Frame Number
 uint8_t got_lsf=0;                  //have we filled the LSF struct yet?
+uint8_t finished=0;
 
 void send_Preamble(const uint8_t type)
 {
@@ -74,6 +75,15 @@ void send_data(uint8_t* in)
 		s=symbol_map[in[2*i]*2+in[2*i+1]];
 		write(STDOUT_FILENO, (uint8_t*)&s, sizeof(float));
 	}
+}
+
+void send_EoT()
+{
+    float symb=+3.0;
+    for(uint16_t i=0; i<192; i++) //40ms * 4800 = 192
+    {
+        write(STDOUT_FILENO, (uint8_t*)&symb,  sizeof(float));
+    }
 }
 
 //out - unpacked bits
@@ -249,17 +259,32 @@ int main(void)
     //printf("%d -> %d -> %d\n", 1, intrl_seq[1], intrl_seq[intrl_seq[1]]); //interleaver bijective reciprocality test, f(f(x))=x
     //return 0;
 
-    while(1)
+    if(fread(&(next_lsf.dst), 6, 1, stdin)<1) finished=1;
+    if(fread(&(next_lsf.src), 6, 1, stdin)<1) finished=1;
+    if(fread(&(next_lsf.type), 2, 1, stdin)<1) finished=1;
+    if(fread(&(next_lsf.meta), 14, 1, stdin)<1) finished=1;
+    if(fread(next_data, 16, 1, stdin)<1) finished=1;
+
+    while(!finished)
     {
+        lsf = next_lsf;
+
+        //calculate LSF CRC
+        uint16_t ccrc=LSF_CRC(&lsf);
+        lsf.crc[0]=ccrc>>8;
+        lsf.crc[1]=ccrc&0xFF;
+
+        memcpy(data, next_data, sizeof(data));
+
+        //we could discard the data we already have
+        if(fread(&(next_lsf.dst), 6, 1, stdin)<1) finished=1;
+        if(fread(&(next_lsf.src), 6, 1, stdin)<1) finished=1;
+        if(fread(&(next_lsf.type), 2, 1, stdin)<1) finished=1;
+        if(fread(&(next_lsf.meta), 14, 1, stdin)<1) finished=1;
+        if(fread(next_data, 16, 1, stdin)<1) finished=1;
+
         if(got_lsf) //stream frames
         {
-            //we could discard the data we already have
-            while(fread(&(lsf.dst), 1, 6, stdin)<1);
-            while(fread(&(lsf.src), 1, 6, stdin)<1);
-            while(fread(&(lsf.type), 1, 2, stdin)<1);
-            while(fread(&(lsf.meta), 1, 14, stdin)<1);
-            while(fread(data, 1, 16, stdin)<1);
-
             //send stream frame syncword
             send_Syncword(SYNC_STR);
 
@@ -352,7 +377,7 @@ int main(void)
             }
 
             //encode the rest of the frame
-            conv_Encode_Frame(&enc_bits[96], data, fn);
+            conv_Encode_Frame(&enc_bits[96], data, finished ? (fn | 0x8000) : fn);
 
             //reorder bits
             for(uint16_t i=0; i<SYM_PER_PLD*2; i++)
@@ -394,17 +419,6 @@ int main(void)
         }
         else //LSF
         {
-            while(fread(&(lsf.dst), 1, 6, stdin)<1);
-            while(fread(&(lsf.src), 1, 6, stdin)<1);
-            while(fread(&(lsf.type), 1, 2, stdin)<1);
-            while(fread(&(lsf.meta), 1, 14, stdin)<1);
-            while(fread(data, 1, 16, stdin)<1);
-
-            //calculate LSF CRC
-            uint16_t ccrc=LSF_CRC(&lsf);
-            lsf.crc[0]=ccrc>>8;
-            lsf.crc[1]=ccrc&0xFF;
-
             got_lsf=1;
 
             //encode LSF data
@@ -457,6 +471,9 @@ int main(void)
                 printf("%02X", lsf.crc[i]);
 			printf("\n");*/
 		}
+
+        if (finished)
+            send_EoT();
 	}
 
 	return 0;

--- a/SP5WWP/m17-decoder/m17-decoder-sym.c
+++ b/SP5WWP/m17-decoder/m17-decoder-sym.c
@@ -94,7 +94,7 @@ int main(void)
     while(1)
     {
         //wait for another symbol
-        while(fread((uint8_t*)&sample, 1, 4, stdin)<1);
+        if(fread((uint8_t*)&sample, 4, 1, stdin)<1) break;
 
         if(!syncd)
         {

--- a/SP5WWP/m17-decoder/m17-decoder.c
+++ b/SP5WWP/m17-decoder/m17-decoder.c
@@ -21,7 +21,7 @@ int main(void)
     while(1)
     {
         //wait for another baseband sample
-        while(fread((uint8_t*)&sample, 1, 2, stdin)<1);
+        if(fread((uint8_t*)&sample, 2, 1, stdin)<1) break;
 
         //push the root-nyquist filter's buffer
         for(uint8_t i=0; i<FLT_LEN-1; i++)

--- a/SP5WWP/m17-packet/m17-packet-encode.c
+++ b/SP5WWP/m17-packet/m17-packet-encode.c
@@ -393,7 +393,11 @@ int main(int argc, char* argv[])
 
     //obtain data and append with CRC
     memset(full_packet_data, 0, 32*25);
-    while(fread(full_packet_data, 1, num_bytes, stdin)<1);
+    if(fread(full_packet_data, num_bytes, 1, stdin)<1)
+    {
+        fprintf(stderr, "Packet data too short. Exiting...\n");
+        return -1;
+    }
     uint16_t packet_crc=CRC_M17(full_packet_data, num_bytes);
     full_packet_data[num_bytes]  =packet_crc>>8;
     full_packet_data[num_bytes+1]=packet_crc&0xFF;


### PR DESCRIPTION
I noticed a few problems with the C utilities:

1. All the utilities enter into an infinite loop when the standard input ends. To fix this, I've replaced the `while` loops with `if` statements that exit if the end of the input is reached.
2. The `size` and `count` arguments to `fread` were reversed. I messed this up in #3, and I've corrected it here.
3. The m17-coder-sym utility never marks the "last" frame (by setting the high bit of the frame number), and doesn't transmit an EoT. To correctly detect the last input frame, I changed the main loop to read one frame ahead, so that the end-of-file condition is triggered in time to set the high bit of  the frame number.