### PR TITLE
Only update the LSF data once per superframe

### DIFF
--- a/SP5WWP/m17-coder/m17-coder-sym.c
+++ b/SP5WWP/m17-coder/m17-coder-sym.c
@@ -267,12 +267,15 @@ int main(void)
 
     while(!finished)
     {
-        lsf = next_lsf;
+        if(lich_cnt == 0)
+        {
+            lsf = next_lsf;
 
-        //calculate LSF CRC
-        uint16_t ccrc=LSF_CRC(&lsf);
-        lsf.crc[0]=ccrc>>8;
-        lsf.crc[1]=ccrc&0xFF;
+            //calculate LSF CRC
+            uint16_t ccrc=LSF_CRC(&lsf);
+            lsf.crc[0]=ccrc>>8;
+            lsf.crc[1]=ccrc&0xFF;
+        }
 
         memcpy(data, next_data, sizeof(data));
 


### PR DESCRIPTION
The m17-coder-sym utility accepts new LSF data once per frame. But if the LSF data is changed in the middle of a superframe, then old & new data are mixed and the resulting CRC is invalid. This can be demonstrated like so:

```
$ dd if=/dev/urandom bs=44 count=20 | m17-coder/m17-coder-sym | m17-decoder/m17-decoder-sym 
LSF
DST: M0ACXWOP6 SRC: KQGGZEUZQ TYPE: 3174 META: A6F8B5134A3439C291F67C9E73D2 LSF_CRC_OK  e=0.0
FN: 0000 PLD: A3E321296A142927C8C33F5D9270D44C e=0.0
FN: 0001 PLD: 50090C7573EB83E881436A35C8FBA302 e=0.0
FN: 0002 PLD: 6A95B4A467D692F3B70C85F0D56918F1 e=0.0
FN: 0003 PLD: 19859DA672CCC55518AE98CC2912586C e=0.0
FN: 0004 PLD: BB9EE0F12AC6563F9626DF2052A2CDA9 e=0.0
DST: .ST6968UA SRC: O8BZD8ZRP TYPE: 5C04 META: BA9119CF1E309B8D5986D95B82FC LSF_CRC_ERR
FN: 0005 PLD: 7259B6D142F623333F3AFE130D4527F6 e=0.0
FN: 0006 PLD: 9923C6674A89B0A4564DDDBB2DC42FFE e=0.0
FN: 0007 PLD: EF62854D197E4273782A17482485C855 e=0.0
FN: 0008 PLD: 411B873428FC295CE505F1E9105CAEFF e=0.0
FN: 0009 PLD: 95D9A55D3D240E77BD164A32E3773CCE e=0.0
FN: 000A PLD: F3D62225428D24BFDA7FCC4E5ECDB93A e=0.0
DST:           SRC: N1VBL/TQQ TYPE: B1A0 META: FFF5179E8BBAE91298217F5C24CB LSF_CRC_ERR
FN: 000B PLD: 8EB8A055B9830F5A8C3B3BE1257794D3 e=0.0
FN: 000C PLD: 532BEBFA7E50D50C8A69F383F716BAA6 e=0.0
FN: 000D PLD: CB3B987927D9EE54517B17CDDBEA47EF e=0.0
FN: 000E PLD: 886F0A8DC0982881A5E770BD82CC2F30 e=0.0
FN: 000F PLD: 5760C9FA2B2D4F878EA3CD972D007186 e=0.0
FN: 0010 PLD: FA5F30C54194C926A6D279FA64628667 e=0.0
DST: 5BNOA829A SRC: I6L5XSSTR TYPE: 4F3F META: 56C68685338902388436E3C95A9A LSF_CRC_ERR
FN: 0011 PLD: 195C9772ABD084D998846FD4CF67E137 e=0.0
FN: 8012 PLD: B48ACFADCEFC9D629AA81B167E498AEF e=0.0
```

To fix this, I've modified the loop to only apply LSF updates at the start of a superframe.