### PR TITLE
Add missing dependencies to makefiles

### DIFF
--- a/SP5WWP/m17-coder/Makefile
+++ b/SP5WWP/m17-coder/Makefile
@@ -1,4 +1,4 @@
-m17-coder-sym: m17-coder-sym.c golay.c crc.c
+m17-coder-sym: m17-coder-sym.c golay.c golay.h crc.c crc.h ../inc/m17.h
 	gcc -O2 -w m17-coder-sym.c golay.c crc.c -o m17-coder-sym -lm
 
 clean:

--- a/SP5WWP/m17-decoder/Makefile
+++ b/SP5WWP/m17-decoder/Makefile
@@ -1,4 +1,4 @@
-m17-decoder-sym: m17-decoder-sym.c golay.c viterbi.c crc.c
+m17-decoder-sym: m17-decoder-sym.c golay.c golay.h viterbi.c viterbi.h crc.c crc.h ../inc/m17.h
 	gcc -Wall -O2 m17-decoder-sym.c golay.c viterbi.c crc.c -o m17-decoder-sym -lm
 
 clean:

--- a/SP5WWP/m17-packet/Makefile
+++ b/SP5WWP/m17-packet/Makefile
@@ -1,14 +1,12 @@
-m17-packet-encode: m17-packet-encode.c crc.c
+m17-packet-encode: m17-packet-encode.c crc.c crc.h ../inc/m17.h
 	gcc -O2 -Wall m17-packet-encode.c crc.c -o m17-packet-encode -lm
 
-m17-packet-decode: m17-packet-decode.c viterbi.c crc.c
+m17-packet-decode: m17-packet-decode.c viterbi.c viterbi.h crc.c crc.h ../inc/m17.h
 	gcc -O2 -Wall m17-packet-decode.c viterbi.c crc.c -o m17-packet-decode -lm
 
-all:
-	gcc -O2 -Wall m17-packet-encode.c crc.c -o m17-packet-encode -lm
-	gcc -O2 -Wall m17-packet-decode.c viterbi.c crc.c -o m17-packet-decode -lm
+all: m17-packet-encode m17-packet-decode
 
-install:
+install: all
 	sudo install m17-packet-encode /usr/local/bin
 	sudo install m17-packet-decode /usr/local/bin
 


### PR DESCRIPTION
The makefiles are missing several dependencies, which means that `make` fails to rebuild if any of these files are changed. Here I've added the missing dependencies.