### PR TITLE
Require the LICH to be from a single superframe

### DIFF
--- a/SP5WWP/m17-decoder/m17-decoder-sym.c
+++ b/SP5WWP/m17-decoder/m17-decoder-sym.c
@@ -24,6 +24,7 @@ uint16_t lich_chunk[96];            //raw, soft LSF chunk extracted from the LIC
 uint8_t lich_b[6];                  //48-bit decoded LICH
 uint8_t lich_cnt;                   //LICH_CNT
 uint8_t lich_chunks_rcvd=0;         //flags set for each LSF chunk received
+uint16_t expected_next_fn=0;        //frame number of the next frame expected to arrive
 
 uint16_t enc_data[272];             //raw frame data soft bits
 uint8_t frame_data[19];             //decoded frame data, 144 bits (16+128), plus 4 flushing bits
@@ -201,6 +202,32 @@ int main(void)
                 //if it is a frame
                 if(!fl)
                 {
+                    //extract data
+                    for(uint16_t i=0; i<272; i++)
+                    {
+                        enc_data[i]=d_soft_bit[96+i];
+                    }
+
+                    //decode
+                    uint32_t e=decodePunctured(frame_data, enc_data, P_2, 272, 12);
+
+                    uint16_t fn = (frame_data[1] << 8) | frame_data[2];
+
+                    //dump data - first byte is empty
+                    printf("FN: %04X PLD: ", fn);
+                    for(uint8_t i=3; i<19; i++)
+                    {
+                        printf("%02X", frame_data[i]);
+                    }
+                    #ifdef SHOW_VITERBI_ERRS
+                    printf(" e=%1.1f\n", (float)e/0xFFFF);
+                    #else
+                    printf("\n");
+                    #endif
+
+                    //send codec2 stream to stdout
+                    //write(STDOUT_FILENO, &frame_data[3], 16);
+
                     //extract LICH
                     for(uint16_t i=0; i<96; i++)
                     {
@@ -210,6 +237,11 @@ int main(void)
                     //Golay decoder
                     decode_LICH(lich_b, lich_chunk);
                     lich_cnt=lich_b[5]>>5;
+
+                    //If we're at the start of a superframe, or we missed a frame, reset the LICH state
+                    if((lich_cnt==0) || ((fn % 0x8000)!=expected_next_fn))
+                        lich_chunks_rcvd=0;
+
                     lich_chunks_rcvd|=(1<<lich_cnt);
                     memcpy(&lsf[lich_cnt*5], lich_b, 5);
 
@@ -262,33 +294,9 @@ int main(void)
                         else
                             printf(" LSF_CRC_OK ");
                         printf("\n");
-
-                        lich_chunks_rcvd=0; //reset all flags
                     }
 
-                    //extract data
-                    for(uint16_t i=0; i<272; i++)
-                    {
-                        enc_data[i]=d_soft_bit[96+i];
-                    }
-
-                    //decode
-                    uint32_t e=decodePunctured(frame_data, enc_data, P_2, 272, 12);
-
-                    //dump data - first byte is empty
-                    printf("FN: %02X%02X PLD: ", frame_data[1], frame_data[2]);
-                    for(uint8_t i=3; i<19; i++)
-                    {
-                        printf("%02X", frame_data[i]);
-                    }
-                    #ifdef SHOW_VITERBI_ERRS
-                    printf(" e=%1.1f\n", (float)e/0xFFFF);
-                    #else
-                    printf("\n");
-                    #endif
-
-                    //send codec2 stream to stdout
-                    //write(STDOUT_FILENO, &frame_data[3], 16);
+                    expected_next_fn = (fn + 1) % 0x8000;
                 }
                 else //lsf
                 {


### PR DESCRIPTION
The M17 specification states that the LSF (in particular, the META field) can change over the course of a transmission. Because the LSF value may vary between superframes, it is unsafe to combine LICH chunks that come from different superframes. The current m17-decoder-sym allows this, and CRC errors can be seen when chunks from different superframes are combined.

To fix this, I adjusted the code to reset `lich_chunks_rcvd` at the start of each superframe, as well as any time a frame is lost. I moved the LICH processing step to be after the data processing step so that the frame number can be used for this purpose.

This change is related to #10, which ensured that the LSF cannot change in the middle of a superframe.

I suppose it might be worth explicitly mentioning in the specification that the LSF must remain the same over the course of a superframe, and that receivers should only reassemble the LICH chunks from within a single superframe.