### PR TITLE
Remove usage of unistd.h

### DIFF
--- a/SP5WWP/m17-coder/Makefile
+++ b/SP5WWP/m17-coder/Makefile
@@ -1,5 +1,5 @@
 m17-coder-sym: m17-coder-sym.c golay.c golay.h crc.c crc.h ../inc/m17.h
-	gcc -O2 -w m17-coder-sym.c golay.c crc.c -o m17-coder-sym -lm
+	gcc -O2 -Wall m17-coder-sym.c golay.c crc.c -o m17-coder-sym -lm
 
 clean:
 	rm m17-coder-sym

--- a/SP5WWP/m17-coder/m17-coder-sym.c
+++ b/SP5WWP/m17-coder/m17-coder-sym.c
@@ -1,7 +1,6 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdint.h>
-#include <unistd.h>
 
 #include "../inc/m17.h"
 #include "golay.h"
@@ -38,9 +37,9 @@ void send_Preamble(const uint8_t type)
         for(uint16_t i=0; i<192/2; i++) //40ms * 4800 = 192
         {
             symb=-3.0;
-            write(STDOUT_FILENO, (uint8_t*)&symb,  sizeof(float));
+            fwrite((uint8_t*)&symb, sizeof(float), 1, stdout);
             symb=+3.0;
-            write(STDOUT_FILENO, (uint8_t*)&symb,  sizeof(float));
+            fwrite((uint8_t*)&symb, sizeof(float), 1, stdout);
         }
     }
     else //pre-LSF
@@ -48,9 +47,9 @@ void send_Preamble(const uint8_t type)
         for(uint16_t i=0; i<192/2; i++) //40ms * 4800 = 192
         {
             symb=+3.0;
-            write(STDOUT_FILENO, (uint8_t*)&symb,  sizeof(float));
+            fwrite((uint8_t*)&symb, sizeof(float), 1, stdout);
             symb=-3.0;
-            write(STDOUT_FILENO, (uint8_t*)&symb,  sizeof(float));
+            fwrite((uint8_t*)&symb, sizeof(float), 1, stdout);
         }
     }
 }
@@ -62,7 +61,7 @@ void send_Syncword(const uint16_t sword)
     for(uint8_t i=0; i<16; i+=2)
     {
         symb=symbol_map[(sword>>(14-i))&3];
-        write(STDOUT_FILENO, (uint8_t*)&symb,  sizeof(float));
+        fwrite((uint8_t*)&symb, sizeof(float), 1, stdout);
     }
 }
 
@@ -73,7 +72,7 @@ void send_data(uint8_t* in)
 	for(uint16_t i=0; i<SYM_PER_PLD; i++) //40ms * 4800 - 8 (syncword)
 	{
 		s=symbol_map[in[2*i]*2+in[2*i+1]];
-		write(STDOUT_FILENO, (uint8_t*)&s, sizeof(float));
+		fwrite((uint8_t*)&s, sizeof(float), 1, stdout);
 	}
 }
 
@@ -82,7 +81,7 @@ void send_EoT()
     float symb=+3.0;
     for(uint16_t i=0; i<192; i++) //40ms * 4800 = 192
     {
-        write(STDOUT_FILENO, (uint8_t*)&symb,  sizeof(float));
+        fwrite((uint8_t*)&symb, sizeof(float), 1, stdout);
     }
 }
 
@@ -398,7 +397,7 @@ int main(void)
             //send dummy symbols (debug)
             /*float s=0.0;
             for(uint8_t i=0; i<SYM_PER_PLD; i++) //40ms * 4800 - 8 (syncword)
-                write(STDOUT_FILENO, (uint8_t*)&s, sizeof(float));*/
+                fwrite((uint8_t*)&s, sizeof(float), 1, stdout);*/
 
 			//send frame data
 			send_data(rf_bits);
@@ -455,7 +454,7 @@ int main(void)
             //send dummy symbols (debug)
             /*float s=0.0;
             for(uint8_t i=0; i<184; i++) //40ms * 4800 - 8 (syncword)
-                write(STDOUT_FILENO, (uint8_t*)&s, sizeof(float));*/
+                write((uint8_t*)&s, sizeof(float), 1, stdout);*/
 
             /*printf("DST: ");
             for(uint8_t i=0; i<6; i++)

--- a/SP5WWP/m17-decoder/m17-decoder-sym.c
+++ b/SP5WWP/m17-decoder/m17-decoder-sym.c
@@ -231,7 +231,7 @@ int main(void)
                     #endif
 
                     //send codec2 stream to stdout
-                    //write(STDOUT_FILENO, &frame_data[3], 16);
+                    //fwrite(&frame_data[3], 16, 1, stdout);
 
                     //extract LICH
                     for(uint16_t i=0; i<96; i++)

--- a/SP5WWP/m17-decoder/m17-decoder.c
+++ b/SP5WWP/m17-decoder/m17-decoder.c
@@ -1,6 +1,5 @@
 #include <stdio.h>
 #include <stdlib.h>
-#include <unistd.h>
 #include <stdint.h>
 
 #include "../inc/m17.h"
@@ -62,9 +61,7 @@ int main(void)
         //detect peak
         if(xc_buff[XC_LEN-1]>0.4*INT16_MAX)
         {
-            uint8_t msg[64];
-            uint8_t len=sprintf(msg, "SYNC\n");
-            write(STDERR_FILENO, msg, len);
+            fprintf(stderr, "SYNC\n");
         }
     }
 

--- a/SP5WWP/m17-decoder/viterbi.c
+++ b/SP5WWP/m17-decoder/viterbi.c
@@ -1,7 +1,6 @@
 #include <stdio.h>
 #include <stdint.h>
 #include <string.h>
-#include <unistd.h>
 #include "viterbi.h"
 
 #define K			5               //constraint length
@@ -27,7 +26,7 @@ uint16_t history[244];
 uint32_t decode(uint8_t* out, const uint16_t* in, uint16_t len)
 {
     if(len > 244*2)
-		fprintf((FILE*)STDERR_FILENO, "Input size exceeds max history\n");
+		fprintf(stderr, "Input size exceeds max history\n");
 
     reset();
 
@@ -57,7 +56,7 @@ uint32_t decode(uint8_t* out, const uint16_t* in, uint16_t len)
 uint32_t decodePunctured(uint8_t* out, const uint16_t* in, const uint8_t* punct, const uint16_t in_len, const uint16_t p_len)
 {
     if(in_len > 244*2)
-		fprintf((FILE*)STDERR_FILENO, "Input size exceeds max history\n");
+		fprintf(stderr, "Input size exceeds max history\n");
 
 	uint16_t umsg[244*2];           //unpunctured message
 	uint8_t p=0;		            //puncturer matrix entry

--- a/SP5WWP/m17-packet/viterbi.c
+++ b/SP5WWP/m17-packet/viterbi.c
@@ -1,7 +1,6 @@
 #include <stdio.h>
 #include <stdint.h>
 #include <string.h>
-#include <unistd.h>
 #include "viterbi.h"
 
 #define K			5               //constraint length
@@ -27,7 +26,7 @@ uint16_t history[244];
 uint32_t decode(uint8_t* out, const uint16_t* in, uint16_t len)
 {
     if(len > 244*2)
-		fprintf((FILE*)STDERR_FILENO, "Input size exceeds max history\n");
+		fprintf(stderr, "Input size exceeds max history\n");
 
     reset();
 
@@ -57,7 +56,7 @@ uint32_t decode(uint8_t* out, const uint16_t* in, uint16_t len)
 uint32_t decodePunctured(uint8_t* out, const uint16_t* in, const uint8_t* punct, const uint16_t in_len, const uint16_t p_len)
 {
     if(in_len > 244*2)
-		fprintf((FILE*)STDERR_FILENO, "Input size exceeds max history\n");
+		fprintf(stderr, "Input size exceeds max history\n");
 
 	uint16_t umsg[244*2];           //unpunctured message
 	uint8_t p=0;		            //puncturer matrix entry


### PR DESCRIPTION
By replacing `write` with `fwrite`, we can eliminate the dependence on the POSIX system call API. This change also fixes the last remaining warnings in `m17-coder-sym`, so `-Wall` can be turned on.