### PR TITLE
PKT Decoder: Fix memcpy to include crc value;

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,8 @@
 /SP5WWP/m17-packet/m17-packet-decode
 /SP5WWP/.vscode
 *.json
+*.rrc
+*.wav
+*.bin
+*.sym
+*.patch

--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@ Written in C, it has all the components described by the protocol's specificatio
 
 There's no support for **any** encryption yet.
 
+### Cloning
+Be sure to clone with `--recursive` to pull the linked libm17 repository, otherwise, building will fail.
+```
+git clone https://github.com/M17-Project/M17_Implementations.git --recursive
+```
+
 ### Building
 First, build the shared object `libm17.so`:
 ```
@@ -76,19 +82,91 @@ Packet encoding is available with `m17-packet-encoder`. Its input parameters are
 -x - binary output (M17 baseband as a packed bitstream)
 -r - raw audio output - default (single channel, signed 16-bit LE, +7168 for the +1.0 symbol, 10 samples per symbol)
 -s - signed 16-bit LE symbols output
+-f - float symbols output compatible with m17-packet-decode
+-d - raw audio output - same as -r, but no RRC filtering (debug)
+-w - libsndfile wav audio output - default (single channel, signed 16-bit LE, +7168 for the +1.0 symbol, 10 samples per symbol)
 ```
 
 Input data is passed over stdin. Example command:
 
-`echo -en "\x05Testing M17 packet mode." | ./m17-packet-encode -S N0CALL -D ALL -C 0 -n 25 -o baseband.rrc`
+`echo -en "\x05Testing M17 packet mode." | ./m17-packet-encode -S N0CALL -D ALL -C 0 -n 25 -f -o baseband.sym`
 
 `-en` parameter for `echo` suppresses the trailing newline character and enables the use of `\` within the message.
 `\x05` sets the packet data content and stands for text message (as per M17 Specification document, chapter 3.2 - Packet Application).
-If a WAVE file format is required for the baseband, sox can be used:
 
-`sox -t raw -r 48000 -b 16 -c 1 -L -e signed-integer baseband.rrc baseband.wav`
+Output:
 
-This line converts .rrc to .wav. SDRangel successfully decoding a packet:
-![SDRangel screen dump](https://github.com/M17-Project/M17_Implementations/assets/44336093/d2cd195c-6126-4b48-b516-36d20dced9ce)
+```
+DST: ALL	FFFFFFFFFFFF
+SRC: N0CALL	00004B13D106
+Data CRC:	BFEC
+LSF  CRC:	432A
+FN:00 (full frame)
+0554657374696E67204D3137207061636B6574206D6F64652E00
+FN:-- (ending frame)
+00BFEC0000000000000000000000000000000000000000000084
+FULL: 0554657374696E67204D3137207061636B6574206D6F64652E00BFEC
+ SMS: Testing M17 packet mode.
+```
 
-The two characters at the end of the message are probably CRC bytes erroneously decoded by SDRangel as a part of the text message.
+Decode packet created with above sample:
+
+`cat baseband.sym | ./m17-packet-decode`
+
+Output: 
+
+```
+DST: FFFFFFFFFFFF SRC: 00004B13D106 TYPE: 0002 META: 0000000000000000000000000000 LSF_CRC_OK 
+Testing M17 packet mode.
+```
+
+Encode directly as wav format (skip sox):
+
+`echo -en "\x05Testing M17 packet mode." | ./m17-packet-encode -S N0CALL -D AB1CDE -C 7 -n 25 -w -o baseband.wav`
+
+Output:
+
+```
+DST: AB1CDE	00001F245D51
+SRC: N0CALL	00004B13D106
+Data CRC:	BFEC
+LSF  CRC:	F754
+FN:00 (full frame)
+0554657374696E67204D3137207061636B6574206D6F64652E00
+FN:-- (ending frame)
+00BFEC0000000000000000000000000000000000000000000084
+FULL: 0554657374696E67204D3137207061636B6574206D6F64652E00BFEC
+ SMS: Testing M17 packet mode.
+```
+
+Decode with M17-FME:
+
+`m17-fme -r -w baseband.wav -v 1`
+
+Output:
+
+```
+M17 Project - Florida Man Edition                          
+Build Version: 2024-1-g4f2c15c 
+Session Number: A4F5 
+M17 Project RF Audio Frame Demodulator. 
+SNDFile (.wav, .rrc) Input File: baseband.wav 
+Payload Verbosity: 1; 
+
+
+M17 LSF Frame Sync (08:57:09): 
+ DST: AB1CDE    SRC: N0CALL    CAN: 7; Data Packet
+ LSF: 00 00 1F 24 5D 51 00 00 4B 13 D1 06 03 82 00
+      00 00 00 00 00 00 00 00 00 00 00 00 00 F7 54
+      (CRC CHK) E: F754; C: F754;
+M17 PKT Frame Sync (08:57:09):  CNT: 00; PBC: 00; EOT: 0;
+ pkt: 0554657374696E67204D3137207061636B6574206D6F64652E00
+M17 PKT Frame Sync (08:57:09):  CNT: 01; LST: 01; EOT: 1;
+ pkt: 00BFEC0000000000000000000000000000000000000000000084 Protocol: SMS;
+ SMS: Testing M17 packet mode.
+ PKT: 05 54 65 73 74 69 6E 67 20 4D 31 37 20 70 61 63 6B 65 74 20 6D 6F 64 65 2E
+      00 BF EC 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+      (CRC CHK) E: BFEC; C: BFEC;
+M17  No Frame Sync (08:57:09): 
+
+```

--- a/SP5WWP/m17-packet/Makefile
+++ b/SP5WWP/m17-packet/Makefile
@@ -1,10 +1,10 @@
 all: m17-packet-encode m17-packet-decode
 
 m17-packet-encode: m17-packet-encode.c
-	gcc -I ../../libm17 -O2 -Wall -Wextra m17-packet-encode.c -o m17-packet-encode -lm -lm17
+	gcc -I ../../libm17 -O2 -Wall -Wextra m17-packet-encode.c -o m17-packet-encode -lm -lm17 -lsndfile
 
 m17-packet-decode: m17-packet-decode.c
-	gcc -I ../../libm17 -O2 -Wall -Wextra m17-packet-decode.c -o m17-packet-decode -lm -lm17
+	gcc -I ../../libm17 -O2 -Wall -Wextra m17-packet-decode.c -o m17-packet-decode -lm -lm17 -lsndfile
 
 install: all
 	sudo install m17-packet-encode /usr/local/bin

--- a/SP5WWP/m17-packet/m17-packet-decode.c
+++ b/SP5WWP/m17-packet/m17-packet-decode.c
@@ -194,7 +194,7 @@ int main(int argc, char* argv[])
                     }
                     else if(rx_last)
                     {
-                        memcpy(&packet_data[(last_fn+1)*25], &frame_data[1], rx_fn);
+                        memcpy(&packet_data[(last_fn+1)*25], &frame_data[1], rx_fn+2); //+2 to include crc
 
                         //dump data
                         if(packet_data[0]==0x05) //if a text message
@@ -207,7 +207,7 @@ int main(int argc, char* argv[])
                             {
                                 uint16_t p_len=strlen((const char*)packet_data);
                                 uint16_t p_crc=CRC_M17(packet_data, p_len+1);
-                                //fprintf(stderr, "rx=%02X%02X calc=%04X", packet_data[p_len+1], packet_data[p_len+2], p_crc);
+                                // fprintf(stderr, "p_len: %d; rx=%02X%02X; calc=%04X;\n", p_len, packet_data[p_len+1], packet_data[p_len+2], p_crc);
                                 if(p_crc==(uint16_t)packet_data[p_len+1]*256+(uint16_t)packet_data[p_len+2])
                                 {
                                     fprintf(stderr, "%s\n", &packet_data[1]);


### PR DESCRIPTION
PKT Encoder: Add Support for libsndfile .wav output and float symbol output files compatible with packet decoder; Fix issue with terminating byte inclusion and extra garbage glyph on encode / decode.

README to include mentions for m17-fme and cross compatibility use;