### PR TITLE
Add install target to m17-coder makefile

### DIFF
--- a/SP5WWP/m17-coder/Makefile
+++ b/SP5WWP/m17-coder/Makefile
@@ -1,5 +1,8 @@
 m17-coder-sym: m17-coder-sym.c
 	gcc -O2 -Wall -Wextra m17-coder-sym.c ../../micro-ecc/uECC.c ../../tinier-aes/aes.c -o m17-coder-sym -lm -lm17
 
+install:
+	sudo cp m17-coder-sym /usr/local/bin
+
 clean:
 	rm -f m17-coder-sym


### PR DESCRIPTION
The m17-coder makefile doesn't have an install target, so I've added one to match the other makefiles.