### PR TITLE
Exit when EOF is detected

### DIFF
--- a/SP5WWP/m17-packet/m17-packet-decode.c
+++ b/SP5WWP/m17-packet/m17-packet-decode.c
@@ -75,11 +75,8 @@ int main(int argc, char* argv[])
         }
     }
 
-    while(1)
+    while(fread((uint8_t*)&sample, 4, 1, stdin) > 0)
     {
-        //wait for another symbol
-        while(fread((uint8_t*)&sample, 4, 1, stdin)<1);
-
         if(!syncd)
         {
             //push new symbol


### PR DESCRIPTION
When the end of the input file is reached, m17-packet-decode enters into an infinite loop and consumes 100% CPU. This can be seen by running `m17-packet-decode -c < symbols.f32`.

The `fread` call returns 0 when EOF has been reached, so m17-packet-decode should exit in this case. If more data may arrive, then `fread` will block and returns 1 once data becomes available.