### PR TITLE
m17-decoder scrambler/signature fix

### DIFF
--- a/SP5WWP/m17-decoder/m17-decoder-sym.c
+++ b/SP5WWP/m17-decoder/m17-decoder-sym.c
@@ -572,6 +572,7 @@ int main(int argc, char* argv[])
                             scrambler_sequence_generator();
                         else if(!signed_str)                    //non-signed stream
                             scrambler_sequence_generator();
+                        else memset(scr_bytes, 0, sizeof(scr_bytes)); //zero out stale scrambler bytes so they aren't applied to the sig frames
                         
                         for(uint8_t i=0; i<16; i++)
                         {


### PR DESCRIPTION
This fixes an issue where stale scrambler bytes are applied to signature frames at the end of transmission, when the signature aren't supposed to be encrypted. I believe this was caused in [this commit](https://github.com/M17-Project/M17_Implementations/commit/a1e81625a3ae4025fe3cb62f514626d063fddcc2) where the fn and sig if condition was moved around and I forgot to account for the application of scr_bytes to the frame data.

```
./m17-coder-sym -D -k 543210 -s 69b07d7afe7f843e56ecbf536a49461dc5901c975d895bf1649cabff8f9b208b > float.sym
Scrambler key: 0x543210 (24-bit)
Signature: E6DADB11ECF2358687FA6B5118FE9DDC
           C6FD15F3FEA742875513BDEF1E6AB8A5
           133DD20B115F5FDD8704C83FE9A5B135
           B19902286DBA60BF99356E7964DDF231
```
Running the debug test before and after the fix shows:
```
cat ../m17-coder/float.sym | ./m17-decoder-sym -s c6c03dd11276aa917e7d83ae16d7f4fbf06f31be5869f9ae8004c329947dc4eeef0d9363653c8edf93e50912c6c515b40e0a8cbeea5e984dbc78e1993c8fbd5d -k 543210
DST: FFFFFFFFFFFF SRC: 00004B13D106 TYPE: 084D (STREAM: VOICE, ENCR: SCRAM 24-bit, CAN: 0, SIGNED) 
FN: 003C PLD: 69696969696969696969696969696969
FN: 7FFC PLD: 297140AA73EDD8D42ED1829B3F86F894
FN: 7FFD PLD: 09568E4861B8AFD5FC3854253912DDED
FN: 7FFE PLD: DC9649B08E40B28F2E2F21F5CEDDD47D
FN: FFFF PLD: 7E329993F2A58DED301E87B343A59779
Signature invalid

```

```
cat ../m17-coder/float.sym | ./m17-decoder-sym -s c6c03dd11276aa917e7d83ae16d7f4fbf06f31be5869f9ae8004c329947dc4eeef0d9363653c8edf93e50912c6c515b40e0a8cbeea5e984dbc78e1993c8fbd5d -k 543210

DST: FFFFFFFFFFFF SRC: 00004B13D106 TYPE: 084D (STREAM: VOICE, ENCR: SCRAM 24-bit, CAN: 0, SIGNED) 
FN: 003C PLD: 69696969696969696969696969696969
FN: 7FFC PLD: E6DADB11ECF2358687FA6B5118FE9DDC
FN: 7FFD PLD: C6FD15F3FEA742875513BDEF1E6AB8A5
FN: 7FFE PLD: 133DD20B115F5FDD8704C83FE9A5B135
FN: FFFF PLD: B19902286DBA60BF99356E7964DDF231
Signature OK

```