### PR TITLE
Fix Misc Debug and Encryption Items;

### DIFF
--- a/SP5WWP/m17-decoder/m17-decoder-sym.c
+++ b/SP5WWP/m17-decoder/m17-decoder-sym.c
@@ -11,7 +11,7 @@
 //tinier-aes
 #include "../../tinier-aes/aes.h"
 
-//TODO: Load Signature Private and Public Keys from file
+//TODO: Set Encryption type and subtype from decoded frame type field, not hard set based on entered values when a key is passed
 
 //settings
 uint8_t decode_callsigns=0;
@@ -74,6 +74,7 @@ uint8_t scrambler_pn[128];
 uint32_t scrambler_key=0; //keep set to initial value for seed calculation function
 uint32_t scrambler_seed=0;
 int8_t scrambler_subtype = -1;
+int8_t aes_subtype = -1;
 
 //debug mode
 uint8_t debug_mode=0; //TODO: Remove lines looking at this
@@ -115,22 +116,21 @@ uint32_t scrambler_seed_calculation(int8_t subtype, uint32_t key, int fn)
   return lfsr;
 }
 
+//set scrambler subtype based on len of key at time of init
+int8_t scrambler_subtype_set(uint32_t scrambler_seed)
+{
+    if      (scrambler_seed > 0 && scrambler_seed <= 0xFF)          return 0; // 8-bit key
+    else if (scrambler_seed > 0xFF && scrambler_seed <= 0xFFFF)     return 1; //16-bit key
+    else if (scrambler_seed > 0xFFFF && scrambler_seed <= 0xFFFFFF) return 2; //24-bit key
+    else                                                            return 0; // 8-bit key (default)
+}
+
 //scrambler pn sequence generation
 void scrambler_sequence_generator()
 {
   int i = 0;
   uint32_t lfsr, bit;
   lfsr = scrambler_seed;
-
-  //only set if not initially set (first run), it is possible (and observed) that the scrambler_subtype can 
-  //change on subsequent passes if the current SEED for the LFSR falls below one of these thresholds
-  if (scrambler_subtype == -1)
-  {
-    if      (lfsr > 0 && lfsr <= 0xFF)          scrambler_subtype = 0; // 8-bit key
-    else if (lfsr > 0xFF && lfsr <= 0xFFFF)     scrambler_subtype = 1; //16-bit key
-    else if (lfsr > 0xFFFF && lfsr <= 0xFFFFFF) scrambler_subtype = 2; //24-bit key
-    else                                        scrambler_subtype = 0; // 8-bit key (default)
-  }
 
   //TODO: Set Frame Type based on scrambler_subtype value
   if (debug_mode>1)
@@ -359,11 +359,20 @@ int main(int argc, char* argv[])
                     fclose(fp);
 
                     if(len==256/4)
+                    {
                         fprintf(stderr, "AES256");
+                        aes_subtype = 2;
+                    }
                     else if(len==192/4)
+                    {
                         fprintf(stderr, "AES192");
+                        aes_subtype = 1;
+                    }  
                     else if(len==128/4)
+                    {
                         fprintf(stderr, "AES128");
+                        aes_subtype = 0;
+                    } 
                     else
                     {
                         fprintf(stderr, "Invalid key length.\n");
@@ -387,11 +396,20 @@ int main(int argc, char* argv[])
                     size_t len = strlen(argv[i+1]);
 
                     if(len==256/4)
+                    {
                         fprintf(stderr, "AES256");
+                        aes_subtype = 2;
+                    }
                     else if(len==192/4)
+                    {
                         fprintf(stderr, "AES192");
+                        aes_subtype = 1;
+                    } 
                     else if(len==128/4)
+                    {
                         fprintf(stderr, "AES128");
+                        aes_subtype = 0;
+                    }
                     else
                     {
                         fprintf(stderr, "Invalid key length.\n");
@@ -441,6 +459,7 @@ int main(int argc, char* argv[])
 
                 encryption=ENCR_SCRAM; //Scrambler key was passed
                 scrambler_seed = scrambler_key; //set initial seed value to key value
+                scrambler_subtype = scrambler_subtype_set(scrambler_seed);
             }
 
             if(!strcmp(argv[i], "-l"))
@@ -556,9 +575,9 @@ int main(int argc, char* argv[])
                         iv[15] = frame_data[2] & 0xFF;
 
                         if(signed_str && (fn % 0x8000)<0x7FFC) //signed stream
-                            aes_ctr_bytewise_payload_crypt(iv, key, frame_data+3, AES128); //hardcoded for now
+                            aes_ctr_bytewise_payload_crypt(iv, key, frame_data+3, aes_subtype);
                         else if(!signed_str)                    //non-signed stream
-                            aes_ctr_bytewise_payload_crypt(iv, key, frame_data+3, AES128); //hardcoded for now
+                            aes_ctr_bytewise_payload_crypt(iv, key, frame_data+3, aes_subtype);
                     }
 
                     //Scrambler


### PR DESCRIPTION
Fix Issues with Initial Link Setup Data Not Carrying Correct Frame Type bits for Encryption Type or Subtype;

Seperate scrambler_subtype_set to a seperate function to call when initializing the scrambler key to fix issue above;

Make aes_subtype variable and initialize before frame type set, and to pass to cipher for true 128, 192, 256 support based on user key;

End Debug Output at Super Frame border (fn==59);